### PR TITLE
perf: use http2 data streams for blindbit client requests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ reqwest = { version = "0.12.4", features = [
   "json",
   "rustls-tls",
   "gzip",
+  "http2",
 ], default-features = false }
 secp256k1 = { version = "0.29.0" }
 


### PR DESCRIPTION
http/2 allows for streaming data over the same network connection, dramantically reducing the number of new web requests that are sent to the blindbit server. I think this can help against some spam detection problems that I'm running into when using a VPN.