### PR TITLE
dep: pin bip321 to optional lightning features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ anyhow = "1.0"
 bech32 = "0.9"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
-bip321 = "0.4.0"
+bip321 = { git="https://gitlab.com/Sosthene00/bark.git", rev="83ab79264159869503b16fa475e0ed61ffa33174", default-features = false }
 bitcoin = { version = "0.32.8", features = ["serde", "rand", "base64"] }
 bitcoin_hashes = "0.13.0"
 rayon = "1.10.0"


### PR DESCRIPTION
The current version of bip321 crate adds lightning and lighting-invoice crate to our dependencies graph. I'm working on a PR on bark to make those dependencies optional. While this is not merged there this PR needs to stay optional