### PR TITLE
build: normalize edition and version across all workspace crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ reqwest = { version = "0.12.4", features = [
 secp256k1 = { version = "0.29.0" }
 
 [workspace.package]
+version = "0.6.0"
+edition = "2024"
 repository = "https://github.com/cygnet3/spdk"
 authors = ["cygnet <cygnet3@proton.me>"]
 license = "MIT"

--- a/backend-blindbit-v1/Cargo.toml
+++ b/backend-blindbit-v1/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "backend-blindbit-v1"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 repository.workspace = true
 
 [lib]

--- a/silentpayments/Cargo.toml
+++ b/silentpayments/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "silentpayments"
-version = "0.6.0"
+version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage = "https://github.com/cygnet3/spdk/tree/master/silentpayments"
-edition = "2024"
+edition.workspace = true
 description = "A library for adding BIP352: Silent Payments support to wallets."
 keywords = ["bitcoin", "secp256k1"]
 readme = "README.md"

--- a/spdk-core/Cargo.toml
+++ b/spdk-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spdk-core"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 repository.workspace = true
 
 [lib]

--- a/spdk-wallet/Cargo.toml
+++ b/spdk-wallet/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spdk-wallet"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 repository.workspace = true
 
 [lib]


### PR DESCRIPTION
Fetch versions from the workspace Cargo.toml instead of defining them in all subcrates.