### PR TITLE
feat(backend): add frigate backend for ephemeral key scanning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["spdk-core", "backend-blindbit-v1", "spdk-wallet", "silentpayments"]
+members = ["spdk-core", "backend-blindbit-v1", "spdk-wallet", "silentpayments", "backend-frigate"]
 resolver = "3"
 
 [workspace.dependencies]
@@ -7,6 +7,7 @@ resolver = "3"
 spdk-core = { path = "spdk-core" }
 silentpayments = { path = "silentpayments" }
 backend-blindbit-v1 = { path = "backend-blindbit-v1"}
+backend-frigate = { path = "backend-frigate"}
 
 # Core dependencies - shared across crates
 anyhow = "1.0"
@@ -28,6 +29,9 @@ reqwest = { version = "0.12.4", features = [
   "gzip",
 ], default-features = false }
 secp256k1 = { version = "0.29.0" }
+
+electrum_streaming_client = { git = "https://github.com/sdmg15/electrum_streaming_client", rev = "f8e9178bf2f67af98364363028d909a65d741834", features = ["frigate"]}
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 [workspace.package]
 repository = "https://github.com/cygnet3/spdk"

--- a/backend-frigate/Cargo.toml
+++ b/backend-frigate/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "backend-frigate"
+version = "0.1.0"
+edition = "2024"
+repository.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+spdk-core.workspace = true
+
+electrum_streaming_client.workspace = true
+tokio.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+bitcoin.workspace = true
+futures.workspace = true
+anyhow.workspace = true
+async-trait.workspace = true
+

--- a/backend-frigate/src/backend.rs
+++ b/backend-frigate/src/backend.rs
@@ -1,0 +1,39 @@
+use anyhow::Result;
+use std::{ops::RangeInclusive, pin::Pin};
+
+use crate::client::FrigateClient;
+use async_trait::async_trait;
+use bitcoin::{Amount, absolute::Height};
+use futures::{Stream, StreamExt, stream};
+use spdk_core::chain::{BlockData, ChainBackend, SpentIndexData, UtxoData};
+
+pub struct FrigateBackend {
+    client: FrigateClient,
+}
+
+impl FrigateBackend {
+    pub fn new(client: FrigateClient) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl ChainBackend for FrigateBackend {
+    fn get_block_data_for_range(
+        &self,
+        range: RangeInclusive<Height>,
+        reverse: bool,
+        dust_limit: Amount,
+        with_cutthrough: bool,
+    ) -> Pin<Box<dyn Stream<Item = Result<BlockData>> + Send>> {
+        todo!()
+    }
+
+    async fn spent_index(&self, block_height: Height) -> Result<SpentIndexData> {
+        todo!()
+    }
+
+    async fn utxos(&self, block_height: Height) -> Result<Vec<UtxoData>> {
+        todo!()
+    }
+}

--- a/backend-frigate/src/client.rs
+++ b/backend-frigate/src/client.rs
@@ -1,0 +1,120 @@
+use std::time::Duration;
+
+use bitcoin::{
+    Txid,
+    secp256k1::{PublicKey, SecretKey},
+};
+use electrum_streaming_client::{AsyncClient, Event, request, response::FullTx};
+use futures::channel::mpsc::UnboundedReceiver;
+use serde::{Deserialize, Serialize};
+use tokio::{net::TcpStream, task::JoinHandle, time::timeout};
+pub struct FrigateClient {
+    pub host_url: String,
+    pub client: AsyncClient,
+    pub events: UnboundedReceiver<Event>,
+    pub worker: JoinHandle<Result<(), std::io::Error>>,
+    pub request_timeout: Duration,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct SubscribeRequest {
+    pub scan_priv_key: SecretKey,
+    pub spend_pub_key: PublicKey,
+    pub start_height: Option<u32>,
+    pub labels: Option<Vec<u32>>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct UnsubscribeRequest {
+    pub scan_priv_key: SecretKey,
+    pub spend_pub_key: PublicKey,
+}
+
+#[derive(Debug)]
+pub enum FrigateError {
+    Serde(serde_json::Error),
+    Generic(String),
+}
+
+impl FrigateClient {
+    pub async fn connect(host_url: &str) -> Result<Self, FrigateError> {
+        let stream = TcpStream::connect(host_url)
+            .await
+            .map_err(|_| FrigateError::Generic("Can't connect to socket".to_string()))?;
+
+        let (reader, writer) = stream.into_split();
+        let (client, events, worker) = AsyncClient::new_tokio(reader, writer);
+
+        let worker: JoinHandle<Result<(), std::io::Error>> = tokio::spawn(async move {
+            if let Err(e) = worker.await {
+                return Err(e);
+            }
+            Ok(())
+        });
+
+        Ok(Self {
+            host_url: host_url.to_string(),
+            client,
+            events,
+            worker,
+            request_timeout: Duration::from_secs(10),
+        })
+    }
+
+    /// Sets a custom request timeout for this client.
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.request_timeout = timeout;
+        self
+    }
+
+    /// Send a request to the Frigate electrum server and return if found
+    // the transaction with the passed txid
+    pub async fn get_transaction(&mut self, txid: Txid) -> Result<FullTx, FrigateError> {
+        let res = timeout(
+            self.request_timeout,
+            self.client.send_request(request::GetTx { txid }),
+        )
+        .await
+        .map_err(|_| FrigateError::Generic("GetTx request timed out".to_string()))?
+        .map_err(|e| FrigateError::Generic(e.to_string()))?;
+        Ok(res)
+    }
+
+    /// Send a request to the Frigate electrum server for version negotiation
+    /// This is the first request that should be sent before subsequent one.
+    pub async fn version(&mut self) -> Result<String, FrigateError> {
+        let res = timeout(
+            self.request_timeout,
+            self.client.send_request(request::ServerVersion {
+                client_name: "silent-payment-dev-kit".into(),
+                protocol_version: request::SupportedVersion::Range(["1.4".into(), "1.6".into()]),
+            }),
+        )
+        .await
+        .map_err(|_| FrigateError::Generic("Version request timed out".to_string()))?
+        .map_err(|e| FrigateError::Generic(e.to_string()))?;
+        Ok(res.protocol_version)
+    }
+
+    /// Make a request to the Frigate electrum server to subscribe to the outputs beloging to the given silent payment address
+    /// Once the server receives the request notification will be sent to the client everytime an ouput is found.
+    ///
+    /// See: <https://github.com/sparrowwallet/frigate#blockchainsilentpaymentssubscribe>
+    pub async fn subscribe(&mut self, req: &SubscribeRequest) -> Result<String, FrigateError> {
+        let subscribe_req = request::SpSubscribe {
+            scan_priv_key: req.scan_priv_key,
+            spend_pub_key: req.spend_pub_key,
+            labels: req.labels.clone(),
+            start_height: req.start_height,
+        };
+
+        let res = timeout(
+            self.request_timeout,
+            self.client.send_request(subscribe_req),
+        )
+        .await
+        .map_err(|_| FrigateError::Generic("Subscribe request timed out".to_string()))?
+        .map_err(|e| FrigateError::Generic(e.to_string()))?;
+        Ok(res)
+    }
+}

--- a/backend-frigate/src/lib.rs
+++ b/backend-frigate/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod backend;
+pub mod client;

--- a/spdk-wallet/Cargo.toml
+++ b/spdk-wallet/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["lib", "staticlib", "cdylib"]
 [dependencies]
 spdk-core.workspace = true
 backend-blindbit-v1 = { workspace = true, optional = true }
+backend-frigate = { workspace = true, optional = true }
 
 anyhow.workspace = true
 bitcoin.workspace = true
@@ -28,3 +29,4 @@ serde_json.workspace = true
 
 [features]
 default = ["backend-blindbit-v1", "rayon"]
+backend-frigate = ["dep:backend-frigate"]

--- a/spdk-wallet/src/lib.rs
+++ b/spdk-wallet/src/lib.rs
@@ -9,6 +9,10 @@ pub use spdk_core::updater;
 #[cfg(feature = "backend-blindbit-v1")]
 pub use backend_blindbit_v1;
 
+// re-export frigate backend if enabled
+#[cfg(feature = "backend-frigate")]
+pub use backend_frigate;
+
 // re-export libraries for consumers
 pub use bitcoin;
 pub use silentpayments;


### PR DESCRIPTION
This PR adds frigate as an alternative backend support.

### Changes 

TBD

### Notes to reviewer

TBD

Closes #147 