### PR TITLE
feat(silentpayments): Make generate_recipient_pubkeys more flexible

### DIFF
--- a/silentpayments/src/sending.rs
+++ b/silentpayments/src/sending.rs
@@ -26,55 +26,59 @@ use crate::utils::sending::calculate_ecdh_shared_secret;
 ///
 /// # Arguments
 ///
-/// * `recipients` - A [Vec] of [`SilentPaymentKeyMaterial`] to be paid.
+/// * `recipients` - An iterable list of recipients to be paid. List can contain either [SilentPaymentKeyMaterial] or [crate::SilentPaymentCode].
 /// * `partial_secret` - [PartialSecret] that represents the sum of the private keys of eligible inputs of the transaction multiplied by the input hash.
 ///
 /// # Returns
 ///
-/// If successful, the function returns a [Result] wrapping a [HashMap] of [`SilentPaymentKeyMaterial`] to a [Vec].
-/// The [Vec] contains all the outputs that are associated with that recipient's key material.
+/// If successful, the function returns a [Result] wrapping a [HashMap] of each recipient item to a [Vec].
+/// The [Vec] contains all the outputs that are associated with that recipient.
+/// If the same recipient was added multiple times, this [Vec] will contain multiple elements.
 ///
 /// # Errors
 ///
 /// This function will return an error if:
 ///
 /// * Edge cases are hit during elliptic curve computation (extremely unlikely).
-pub fn generate_recipient_pubkeys(
-    recipients: Vec<SilentPaymentKeyMaterial>,
+pub fn generate_recipient_pubkeys<T, I>(
+    recipients: I,
     partial_secret: PartialSecret,
-) -> Result<HashMap<SilentPaymentKeyMaterial, Vec<XOnlyPublicKey>>> {
+) -> Result<HashMap<T, Vec<XOnlyPublicKey>>>
+where
+    T: Into<SilentPaymentKeyMaterial> + Eq + std::hash::Hash + Clone + Copy,
+    I: IntoIterator<Item = T>,
+{
     let secp = Secp256k1::new();
 
-    let mut silent_payment_groups: HashMap<
-        PublicKey,
-        (SharedSecret, Vec<SilentPaymentKeyMaterial>),
-    > = HashMap::new();
-    for key_material in recipients {
+    let mut silent_payment_groups: HashMap<PublicKey, (SharedSecret, Vec<T>)> = HashMap::new();
+    for recipient in recipients {
+        let key_material = recipient.into();
+
         let recipient_scan_key = key_material.scan_key();
 
         if let Some((_, payments)) = silent_payment_groups.get_mut(&recipient_scan_key) {
-            payments.push(key_material);
+            payments.push(recipient);
         } else {
             let ecdh_shared_secret =
                 calculate_ecdh_shared_secret(&recipient_scan_key, &partial_secret);
 
-            silent_payment_groups
-                .insert(recipient_scan_key, (ecdh_shared_secret, vec![key_material]));
+            silent_payment_groups.insert(recipient_scan_key, (ecdh_shared_secret, vec![recipient]));
         }
     }
 
-    let mut result: HashMap<SilentPaymentKeyMaterial, Vec<XOnlyPublicKey>> = HashMap::new();
+    let mut result: HashMap<T, Vec<XOnlyPublicKey>> = HashMap::new();
     for group in silent_payment_groups.into_values() {
         let (ecdh_shared_secret, recipients) = group;
 
-        for (n, key_material) in recipients.into_iter().enumerate() {
+        for (n, recipient) in recipients.into_iter().enumerate() {
+            let recipient_key_material = recipient.into();
             let t_n = calculate_t_n(&ecdh_shared_secret, n as u32)?;
 
             let res = t_n.public_key(&secp);
-            let reskey = res.combine(&key_material.m_pubkey())?;
+            let reskey = res.combine(&recipient_key_material.m_pubkey())?;
             let (reskey_xonly, _) = reskey.x_only_public_key();
 
-            let entry = result.entry(key_material).or_default();
+            let entry = result.entry(recipient).or_default();
             entry.push(reskey_xonly);
         }
     }

--- a/silentpayments/tests/common/utils.rs
+++ b/silentpayments/tests/common/utils.rs
@@ -3,7 +3,7 @@ use std::{fs::File, io::Read, str::FromStr};
 use bitcoin_hashes::Hash;
 use secp256k1::{Message, Scalar, SecretKey, XOnlyPublicKey};
 use serde_json::from_str;
-use silentpayments::{SilentPaymentCode, SilentPaymentKeyMaterial};
+use silentpayments::SilentPaymentCode;
 
 use super::structs::{OutputWithSignature, TestData};
 
@@ -63,13 +63,10 @@ pub fn decode_outputs_to_check(outputs: &[String]) -> Vec<XOnlyPublicKey> {
         .collect()
 }
 
-pub fn decode_recipients(recipients: &[String]) -> Vec<SilentPaymentKeyMaterial> {
+pub fn decode_recipients(recipients: &[String]) -> Vec<SilentPaymentCode> {
     recipients
         .iter()
-        .map(|sp_code_str| {
-            let code: SilentPaymentCode = sp_code_str.as_str().try_into().unwrap();
-            SilentPaymentKeyMaterial::from(code)
-        })
+        .map(|sp_code_str| sp_code_str.as_str().try_into().unwrap())
         .collect()
 }
 

--- a/silentpayments/tests/vector_tests.rs
+++ b/silentpayments/tests/vector_tests.rs
@@ -76,12 +76,12 @@ mod tests {
 
             // we drop the amounts from the test here, since we don't work with amounts
             // the wallet should make sure the amount sent are correct
-            let silent_key_material = decode_recipients(&given.recipients);
+            let silent_payment_codes = decode_recipients(&given.recipients);
 
             // as an alternative, we could first multiply each input priv key with the input hash
             // that way, we never expose the sk to our library
             let partial_secret = calculate_partial_secret(&input_priv_keys, &outpoints).unwrap();
-            let outputs = generate_recipient_pubkeys(silent_key_material, partial_secret).unwrap();
+            let outputs = generate_recipient_pubkeys(silent_payment_codes, partial_secret).unwrap();
 
             for output_pubkeys in &outputs {
                 for pubkey in output_pubkeys.1 {

--- a/spdk-wallet/src/client/spend.rs
+++ b/spdk-wallet/src/client/spend.rs
@@ -16,9 +16,9 @@ use bitcoin::transaction::Version;
 use bitcoin::{
     Amount, Network, OutPoint, ScriptBuf, Sequence, TapLeafHash, Transaction, TxIn, TxOut, Witness,
 };
-use silentpayments::utils as sp_utils;
+use silentpayments::Network as SpNetwork;
 use silentpayments::utils::sending::PartialSecret;
-use silentpayments::{Network as SpNetwork, SilentPaymentKeyMaterial};
+use silentpayments::{SilentPaymentCode, utils as sp_utils};
 
 use spdk_core::constants::{DATA_CARRIER_SIZE, NUMS};
 use spdk_core::updater::DiscoveredOutput;
@@ -265,17 +265,17 @@ impl SpClient {
             })
             .collect();
 
-        let sp_key_material: Vec<SilentPaymentKeyMaterial> = unsigned_transaction
+        let recipient_codes: Vec<SilentPaymentCode> = unsigned_transaction
             .recipients
             .iter()
             .filter_map(|r| match &r.address {
-                RecipientAddress::SpCode(sp_code) => Some(SilentPaymentKeyMaterial::from(*sp_code)),
+                RecipientAddress::SpCode(sp_code) => Some(*sp_code),
                 _ => None,
             })
             .collect();
 
         let sp_key_material2xonlypubkeys = silentpayments::sending::generate_recipient_pubkeys(
-            sp_key_material,
+            recipient_codes,
             unsigned_transaction.partial_secret,
         )?;
 
@@ -286,7 +286,7 @@ impl SpClient {
                 RecipientAddress::SpCode(sp_code) => {
                     // We now need to fill the sp outputs with actual spk
                     let pubkeys = sp_key_material2xonlypubkeys
-                        .get(&SilentPaymentKeyMaterial::from(*sp_code))
+                        .get(sp_code)
                         .ok_or(Error::msg("Unknown silent payment key material"))?;
 
                     // we currently only allow having 1 output per silent payment key material


### PR DESCRIPTION
- Accept any iterable list, not just a Vec.
- Accept both SilentPaymentCode and SilentPaymentKeyMaterial. Often times I've noticed that the caller ends up having to manually iterate and convert these structs themselves, so we might as well simplify it by allowing both.
- Return either SilentPaymentCode or SilentPaymentKeyMaterial depending on which was used as an input.