### PR TITLE
feat(core): make block data generic

### DIFF
--- a/backend-blindbit-v1/src/api_structs.rs
+++ b/backend-blindbit-v1/src/api_structs.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 use bitcoin::{Amount, BlockHash, Network, ScriptBuf, Txid, absolute::Height};
 use serde::{Deserialize, Deserializer, Serialize};
-use spdk_core::chain::{FilterData, SpentIndexData, UtxoData};
+use spdk_core::chain::{SpentIndexData, UtxoData};
 
 #[derive(Debug, Deserialize)]
 pub struct BlockHeightResponse {
@@ -59,15 +59,6 @@ pub struct FilterResponse {
     pub block_height: Height,
     pub data: MyHex,
     pub filter_type: i32,
-}
-
-impl From<FilterResponse> for FilterData {
-    fn from(value: FilterResponse) -> Self {
-        Self {
-            block_hash: value.block_hash,
-            data: value.data.hex,
-        }
-    }
 }
 
 #[derive(Debug, Serialize)]

--- a/backend-blindbit-v1/src/backend.rs
+++ b/backend-blindbit-v1/src/backend.rs
@@ -1,13 +1,13 @@
-use std::{ops::RangeInclusive, pin::Pin};
+use std::{collections::HashSet, ops::RangeInclusive, pin::Pin};
 
-use anyhow::Result;
+use anyhow::{Result, bail};
 use async_trait::async_trait;
-use bitcoin::{Amount, absolute::Height};
+use bitcoin::{Amount, BlockHash, OutPoint, absolute::Height};
 use futures::{Stream, StreamExt, stream};
 
 use spdk_core::chain::{BoxedBlockData, ChainBackend, SpentIndexData, UtxoData};
 
-use crate::{BlindbitClient, structs::BlindbitV1BlockData};
+use crate::{BlindbitClient, structs::BlindbitV1BlockData, utils::input_hashes_map};
 
 const CONCURRENT_FILTER_REQUESTS: usize = 200;
 
@@ -66,8 +66,31 @@ impl ChainBackend for BlindbitBackend {
         Box::pin(res)
     }
 
-    async fn spent_index(&self, block_height: Height) -> Result<SpentIndexData> {
-        self.client.spent_index(block_height).await.map(Into::into)
+    async fn detect_spent_outpoints(
+        &self,
+        block_height: Height,
+        block_hash: BlockHash,
+        outpoints: HashSet<OutPoint>,
+    ) -> Result<HashSet<OutPoint>> {
+        let response = self.client.spent_index(block_height).await?;
+        if block_hash != response.block_hash {
+            bail!("Mismatched block hash");
+        }
+
+        let index_data: SpentIndexData = response.into();
+
+        let input_hashes_map = input_hashes_map(&outpoints, block_hash)?;
+
+        let mut res = HashSet::new();
+
+        for spent in index_data.data {
+            let hex: &[u8] = spent.as_ref();
+            if let Some(outpoint) = input_hashes_map.get(hex) {
+                res.insert(*outpoint);
+            }
+        }
+
+        Ok(res)
     }
 
     async fn utxos(&self, block_height: Height) -> Result<Vec<UtxoData>> {

--- a/backend-blindbit-v1/src/backend.rs
+++ b/backend-blindbit-v1/src/backend.rs
@@ -5,9 +5,9 @@ use async_trait::async_trait;
 use bitcoin::{Amount, absolute::Height};
 use futures::{Stream, StreamExt, stream};
 
-use spdk_core::chain::{BlockData, ChainBackend, SpentIndexData, UtxoData};
+use spdk_core::chain::{BoxedBlockData, ChainBackend, SpentIndexData, UtxoData};
 
-use crate::BlindbitClient;
+use crate::{BlindbitClient, structs::BlindbitV1BlockData};
 
 const CONCURRENT_FILTER_REQUESTS: usize = 200;
 
@@ -33,7 +33,7 @@ impl ChainBackend for BlindbitBackend {
         range: RangeInclusive<Height>,
         dust_limit: Amount,
         with_cutthrough: bool,
-    ) -> Pin<Box<dyn Stream<Item = Result<BlockData>> + Send>> {
+    ) -> Pin<Box<dyn Stream<Item = Result<BoxedBlockData>> + Send>> {
         let client = self.client.clone();
 
         // convert range to u32 since Height does not implement Step
@@ -52,13 +52,13 @@ impl ChainBackend for BlindbitBackend {
                     let new_utxo_filter = client.filter_new_utxos(blkheight).await?;
                     let spent_filter = client.filter_spent(blkheight).await?;
                     let blkhash = new_utxo_filter.block_hash;
-                    Ok(BlockData {
+                    Ok(Box::new(BlindbitV1BlockData {
                         blkheight,
                         blkhash,
                         tweaks,
                         new_utxo_filter: new_utxo_filter.into(),
                         spent_filter: spent_filter.into(),
-                    })
+                    }) as BoxedBlockData)
                 }
             })
             .buffered(CONCURRENT_FILTER_REQUESTS);

--- a/backend-blindbit-v1/src/lib.rs
+++ b/backend-blindbit-v1/src/lib.rs
@@ -2,6 +2,7 @@ pub mod api_structs;
 mod backend;
 mod client;
 pub mod structs;
+pub mod utils;
 
 pub use backend::BlindbitBackend;
 pub use client::BlindbitClient;

--- a/backend-blindbit-v1/src/lib.rs
+++ b/backend-blindbit-v1/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod api_structs;
 mod backend;
 mod client;
+pub mod structs;
 
 pub use backend::BlindbitBackend;
 pub use client::BlindbitClient;

--- a/backend-blindbit-v1/src/structs.rs
+++ b/backend-blindbit-v1/src/structs.rs
@@ -1,0 +1,102 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::api_structs::FilterResponse;
+use bitcoin::{
+    BlockHash, OutPoint,
+    absolute::Height,
+    bip158::BlockFilter,
+    hashes::{Hash, sha256},
+    secp256k1::PublicKey,
+};
+use spdk_core::chain::BlockData;
+
+pub struct BlindbitV1BlockData {
+    pub blkheight: Height,
+    pub blkhash: BlockHash,
+    pub tweaks: Vec<PublicKey>,
+    pub new_utxo_filter: FilterData,
+    pub spent_filter: FilterData,
+}
+
+pub struct FilterData {
+    pub block_hash: BlockHash,
+    pub data: Vec<u8>,
+}
+
+impl From<FilterResponse> for FilterData {
+    fn from(value: FilterResponse) -> Self {
+        Self {
+            block_hash: value.block_hash,
+            data: value.data.hex,
+        }
+    }
+}
+
+impl BlockData for BlindbitV1BlockData {
+    fn blkheight(&self) -> Height {
+        self.blkheight
+    }
+
+    fn blkhash(&self) -> BlockHash {
+        self.blkhash
+    }
+
+    fn tweaks(&self) -> Vec<PublicKey> {
+        self.tweaks.clone()
+    }
+
+    fn check_match_outputs(&self, candidate_spks: Vec<&[u8; 34]>) -> anyhow::Result<bool> {
+        // check output scripts
+        let output_keys: Vec<_> = candidate_spks
+            .into_iter()
+            .map(|spk| spk[2..].as_ref())
+            .collect();
+
+        // note: match will always return true for an empty query!
+        if !output_keys.is_empty() {
+            let filter = BlockFilter::new(&self.new_utxo_filter.data);
+
+            Ok(filter.match_any(&self.blkhash, &mut output_keys.into_iter())?)
+        } else {
+            Ok(false)
+        }
+    }
+
+    // Check if this block contains relevant transactions
+    fn check_match_inputs(&self, owned_outpoints: &HashSet<OutPoint>) -> anyhow::Result<bool> {
+        let input_hashes_map = self.input_hashes_map(owned_outpoints)?;
+
+        let input_hashes: Vec<[u8; 8]> = input_hashes_map.keys().cloned().collect();
+
+        // note: match will always return true for an empty query!
+        if !input_hashes.is_empty() {
+            let filter = BlockFilter::new(&self.spent_filter.data);
+
+            Ok(filter.match_any(&self.blkhash, &mut input_hashes.into_iter())?)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn input_hashes_map(
+        &self,
+        owned_outpoints: &HashSet<OutPoint>,
+    ) -> anyhow::Result<HashMap<[u8; 8], OutPoint>> {
+        let mut map: HashMap<[u8; 8], OutPoint> = HashMap::new();
+
+        for outpoint in owned_outpoints {
+            let mut arr = [0u8; 68];
+            arr[..32].copy_from_slice(&outpoint.txid.to_raw_hash().to_byte_array());
+            arr[32..36].copy_from_slice(&outpoint.vout.to_le_bytes());
+            arr[36..].copy_from_slice(&self.blkhash.to_byte_array());
+            let hash = sha256::Hash::hash(&arr);
+
+            let mut res = [0u8; 8];
+            res.copy_from_slice(&hash[..8]);
+
+            map.insert(res, *outpoint);
+        }
+
+        Ok(map)
+    }
+}

--- a/backend-blindbit-v1/src/structs.rs
+++ b/backend-blindbit-v1/src/structs.rs
@@ -1,13 +1,8 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 use crate::api_structs::FilterResponse;
-use bitcoin::{
-    BlockHash, OutPoint,
-    absolute::Height,
-    bip158::BlockFilter,
-    hashes::{Hash, sha256},
-    secp256k1::PublicKey,
-};
+use crate::utils::input_hashes_map;
+use bitcoin::{BlockHash, OutPoint, absolute::Height, bip158::BlockFilter, secp256k1::PublicKey};
 use spdk_core::chain::BlockData;
 
 pub struct BlindbitV1BlockData {
@@ -64,7 +59,7 @@ impl BlockData for BlindbitV1BlockData {
 
     // Check if this block contains relevant transactions
     fn check_match_inputs(&self, owned_outpoints: &HashSet<OutPoint>) -> anyhow::Result<bool> {
-        let input_hashes_map = self.input_hashes_map(owned_outpoints)?;
+        let input_hashes_map = input_hashes_map(owned_outpoints, self.blkhash)?;
 
         let input_hashes: Vec<[u8; 8]> = input_hashes_map.keys().cloned().collect();
 
@@ -76,27 +71,5 @@ impl BlockData for BlindbitV1BlockData {
         } else {
             Ok(false)
         }
-    }
-
-    fn input_hashes_map(
-        &self,
-        owned_outpoints: &HashSet<OutPoint>,
-    ) -> anyhow::Result<HashMap<[u8; 8], OutPoint>> {
-        let mut map: HashMap<[u8; 8], OutPoint> = HashMap::new();
-
-        for outpoint in owned_outpoints {
-            let mut arr = [0u8; 68];
-            arr[..32].copy_from_slice(&outpoint.txid.to_raw_hash().to_byte_array());
-            arr[32..36].copy_from_slice(&outpoint.vout.to_le_bytes());
-            arr[36..].copy_from_slice(&self.blkhash.to_byte_array());
-            let hash = sha256::Hash::hash(&arr);
-
-            let mut res = [0u8; 8];
-            res.copy_from_slice(&hash[..8]);
-
-            map.insert(res, *outpoint);
-        }
-
-        Ok(map)
     }
 }

--- a/backend-blindbit-v1/src/utils.rs
+++ b/backend-blindbit-v1/src/utils.rs
@@ -1,0 +1,28 @@
+use std::collections::{HashMap, HashSet};
+
+use bitcoin::{
+    BlockHash, OutPoint,
+    hashes::{Hash, sha256},
+};
+
+pub fn input_hashes_map(
+    owned_outpoints: &HashSet<OutPoint>,
+    blkhash: BlockHash,
+) -> anyhow::Result<HashMap<[u8; 8], OutPoint>> {
+    let mut map: HashMap<[u8; 8], OutPoint> = HashMap::new();
+
+    for outpoint in owned_outpoints {
+        let mut arr = [0u8; 68];
+        arr[..32].copy_from_slice(&outpoint.txid.to_raw_hash().to_byte_array());
+        arr[32..36].copy_from_slice(&outpoint.vout.to_le_bytes());
+        arr[36..].copy_from_slice(&blkhash.to_byte_array());
+        let hash = sha256::Hash::hash(&arr);
+
+        let mut res = [0u8; 8];
+        res.copy_from_slice(&hash[..8]);
+
+        map.insert(res, *outpoint);
+    }
+
+    Ok(map)
+}

--- a/spdk-core/src/chain/mod.rs
+++ b/spdk-core/src/chain/mod.rs
@@ -2,4 +2,6 @@ mod structs;
 mod r#trait;
 
 pub use structs::*;
+pub use r#trait::BlockData;
+pub use r#trait::BoxedBlockData;
 pub use r#trait::ChainBackend;

--- a/spdk-core/src/chain/structs.rs
+++ b/spdk-core/src/chain/structs.rs
@@ -1,12 +1,4 @@
-use bitcoin::{Amount, BlockHash, ScriptBuf, Txid, absolute::Height, secp256k1::PublicKey};
-
-pub struct BlockData {
-    pub blkheight: Height,
-    pub blkhash: BlockHash,
-    pub tweaks: Vec<PublicKey>,
-    pub new_utxo_filter: FilterData,
-    pub spent_filter: FilterData,
-}
+use bitcoin::{Amount, ScriptBuf, Txid};
 
 pub struct UtxoData {
     pub txid: Txid,
@@ -18,9 +10,4 @@ pub struct UtxoData {
 
 pub struct SpentIndexData {
     pub data: Vec<Vec<u8>>,
-}
-
-pub struct FilterData {
-    pub block_hash: BlockHash,
-    pub data: Vec<u8>,
 }

--- a/spdk-core/src/chain/trait.rs
+++ b/spdk-core/src/chain/trait.rs
@@ -1,15 +1,11 @@
-use std::{
-    collections::{HashMap, HashSet},
-    ops::RangeInclusive,
-    pin::Pin,
-};
+use std::{collections::HashSet, ops::RangeInclusive, pin::Pin};
 
 use anyhow::Result;
 use async_trait::async_trait;
 use bitcoin::{Amount, BlockHash, OutPoint, absolute::Height, secp256k1::PublicKey};
 use futures::Stream;
 
-use super::structs::{SpentIndexData, UtxoData};
+use super::structs::UtxoData;
 
 pub type BoxedBlockData = Box<dyn BlockData + Send + Sync>;
 
@@ -22,7 +18,15 @@ pub trait ChainBackend {
         with_cutthrough: bool,
     ) -> Pin<Box<dyn Stream<Item = Result<BoxedBlockData>> + Send>>;
 
-    async fn spent_index(&self, block_height: Height) -> Result<SpentIndexData>;
+    /// returns all spent outpoints from a provided list of outpoints at this height.
+    /// We also pass the block_hash here, to make sure the block data still matches the expected
+    /// block from get_block_data_for_range.
+    async fn detect_spent_outpoints(
+        &self,
+        block_height: Height,
+        block_hash: BlockHash,
+        outpoints: HashSet<OutPoint>,
+    ) -> Result<HashSet<OutPoint>>;
 
     async fn utxos(&self, block_height: Height) -> Result<Vec<UtxoData>>;
 }
@@ -40,10 +44,4 @@ pub trait BlockData {
 
     /// Fetch the transaction tweaks from this block.
     fn tweaks(&self) -> Vec<PublicKey>;
-
-    // temporary, will be dropped later
-    fn input_hashes_map(
-        &self,
-        owned_outpoints: &HashSet<OutPoint>,
-    ) -> anyhow::Result<HashMap<[u8; 8], OutPoint>>;
 }

--- a/spdk-core/src/chain/trait.rs
+++ b/spdk-core/src/chain/trait.rs
@@ -1,11 +1,17 @@
-use std::{ops::RangeInclusive, pin::Pin};
+use std::{
+    collections::{HashMap, HashSet},
+    ops::RangeInclusive,
+    pin::Pin,
+};
 
 use anyhow::Result;
 use async_trait::async_trait;
-use bitcoin::{Amount, absolute::Height};
+use bitcoin::{Amount, BlockHash, OutPoint, absolute::Height, secp256k1::PublicKey};
 use futures::Stream;
 
-use super::structs::{BlockData, SpentIndexData, UtxoData};
+use super::structs::{SpentIndexData, UtxoData};
+
+pub type BoxedBlockData = Box<dyn BlockData + Send + Sync>;
 
 #[async_trait]
 pub trait ChainBackend {
@@ -14,9 +20,30 @@ pub trait ChainBackend {
         range: RangeInclusive<Height>,
         dust_limit: Amount,
         with_cutthrough: bool,
-    ) -> Pin<Box<dyn Stream<Item = Result<BlockData>> + Send>>;
+    ) -> Pin<Box<dyn Stream<Item = Result<BoxedBlockData>> + Send>>;
 
     async fn spent_index(&self, block_height: Height) -> Result<SpentIndexData>;
 
     async fn utxos(&self, block_height: Height) -> Result<Vec<UtxoData>>;
+}
+
+pub trait BlockData {
+    fn blkheight(&self) -> Height;
+
+    fn blkhash(&self) -> BlockHash;
+
+    /// Checks if any of the outputs in the block matches the provided list of scriptpubkeys
+    fn check_match_outputs(&self, candidate_spks: Vec<&[u8; 34]>) -> anyhow::Result<bool>;
+
+    /// Check if any of the provided set in outpoints are spent in this block
+    fn check_match_inputs(&self, owned_outpoints: &HashSet<OutPoint>) -> anyhow::Result<bool>;
+
+    /// Fetch the transaction tweaks from this block.
+    fn tweaks(&self) -> Vec<PublicKey>;
+
+    // temporary, will be dropped later
+    fn input_hashes_map(
+        &self,
+        owned_outpoints: &HashSet<OutPoint>,
+    ) -> anyhow::Result<HashMap<[u8; 8], OutPoint>>;
 }

--- a/spdk-wallet/src/scanner/scanner.rs
+++ b/spdk-wallet/src/scanner/scanner.rs
@@ -6,18 +6,12 @@ use std::{
 };
 
 use anyhow::{Error, Result};
-use bitcoin::{
-    Amount, BlockHash, OutPoint, Txid, XOnlyPublicKey,
-    absolute::Height,
-    bip158::BlockFilter,
-    hashes::{Hash, sha256},
-    secp256k1::{PublicKey, Scalar},
-};
+use bitcoin::{Amount, OutPoint, Txid, XOnlyPublicKey, absolute::Height, secp256k1::Scalar};
 use futures::{Stream, StreamExt, pin_mut};
 use log::info;
 use silentpayments::{SharedSecret, receiving::Label};
 
-use spdk_core::chain::{BlockData, ChainBackend, FilterData, UtxoData};
+use spdk_core::chain::{BoxedBlockData, ChainBackend, UtxoData};
 use spdk_core::updater::{DiscoveredOutput, Updater};
 
 use crate::client::SpClient;
@@ -79,7 +73,7 @@ impl<'a> SpScanner<'a> {
 
     async fn process_blocks(
         &mut self,
-        block_data_stream: impl Stream<Item = Result<BlockData>>,
+        block_data_stream: impl Stream<Item = Result<BoxedBlockData>>,
     ) -> Result<()> {
         pin_mut!(block_data_stream);
 
@@ -92,12 +86,12 @@ impl<'a> SpScanner<'a> {
             }
 
             let blockdata = blockdata?;
-            let blkhash = blockdata.blkhash;
-            let blkheight = blockdata.blkheight;
+            let blkhash = blockdata.blkhash();
+            let blkheight = blockdata.blkheight();
 
-            tweak_count += blockdata.tweaks.len();
+            tweak_count += blockdata.tweaks().len();
 
-            let (discovered_outputs, discovered_inputs) = self.process_block(blockdata).await?;
+            let (discovered_outputs, discovered_inputs) = self.process_block(&blockdata).await?;
 
             self.updater.record_block_scan_result(
                 blkheight,
@@ -114,24 +108,14 @@ impl<'a> SpScanner<'a> {
 
     async fn process_block(
         &mut self,
-        blockdata: BlockData,
+        blockdata: &BoxedBlockData,
     ) -> Result<(HashMap<OutPoint, DiscoveredOutput>, HashSet<OutPoint>)> {
-        let BlockData {
-            blkheight,
-            tweaks,
-            new_utxo_filter,
-            spent_filter,
-            ..
-        } = blockdata;
-
-        let outs = self
-            .process_block_outputs(blkheight, tweaks, new_utxo_filter)
-            .await?;
+        let outs = self.process_block_outputs(blockdata).await?;
 
         // after processing outputs, we add the found outputs to our list
         self.owned_outpoints.extend(outs.keys());
 
-        let ins = self.process_block_inputs(blkheight, spent_filter).await?;
+        let ins = self.process_block_inputs(blockdata).await?;
 
         // after processing inputs, we remove the found inputs
         self.owned_outpoints.retain(|item| !ins.contains(item));
@@ -141,11 +125,11 @@ impl<'a> SpScanner<'a> {
 
     async fn process_block_outputs(
         &self,
-        blkheight: Height,
-        tweaks: Vec<PublicKey>,
-        new_utxo_filter: FilterData,
+        blockdata: &BoxedBlockData,
     ) -> Result<HashMap<OutPoint, DiscoveredOutput>> {
         let mut res = HashMap::new();
+
+        let tweaks = blockdata.tweaks();
 
         if !tweaks.is_empty() {
             let secrets_map = self.client.script_to_secret_map(tweaks)?;
@@ -153,16 +137,12 @@ impl<'a> SpScanner<'a> {
             //last_scan = last_scan.max(n as u32);
             let candidate_spks: Vec<&[u8; 34]> = secrets_map.keys().collect();
 
-            //get block gcs & check match
-            let blkfilter = BlockFilter::new(&new_utxo_filter.data);
-            let blkhash = new_utxo_filter.block_hash;
-
-            let matched_outputs = Self::check_block_outputs(blkfilter, blkhash, candidate_spks)?;
+            let matched_outputs = blockdata.check_match_outputs(candidate_spks)?;
 
             //if match: fetch and scan utxos
             if matched_outputs {
-                info!("matched outputs on: {}", blkheight);
-                let found = self.scan_utxos(blkheight, secrets_map).await?;
+                info!("matched outputs on: {}", blockdata.blkheight());
+                let found = self.scan_utxos(blockdata.blkheight(), secrets_map).await?;
 
                 if !found.is_empty() {
                     for (label, utxo, tweak) in found {
@@ -188,32 +168,20 @@ impl<'a> SpScanner<'a> {
 
     async fn process_block_inputs(
         &self,
-        blkheight: Height,
-        spent_filter: FilterData,
+        blockdata: &(dyn BlockData + Send + Sync),
     ) -> Result<HashSet<OutPoint>> {
         let mut res = HashSet::new();
 
-        let blkhash = spent_filter.block_hash;
-
-        // first get the 8-byte hashes used to construct the input filter
-        let input_hashes_map = self.get_input_hashes(blkhash)?;
-
-        // check against filter
-        let blkfilter = BlockFilter::new(&spent_filter.data);
-        let matched_inputs = self.check_block_inputs(
-            blkfilter,
-            blkhash,
-            input_hashes_map.keys().cloned().collect(),
-        )?;
+        let match_on_inputs = blockdata.check_match_inputs(&self.owned_outpoints)?;
 
         // if match: download spent data, collect the outpoints that are spent
-        if matched_inputs {
-            info!("matched inputs on: {}", blkheight);
-            let spent = self.backend.spent_index(blkheight).await?.data;
+        if match_on_inputs {
+            info!("matched inputs on: {}", blockdata.blkheight());
+            let spent = self.backend.spent_index(blockdata.blkheight()).await?.data;
+            let input_hashes_map = blockdata.input_hashes_map(&self.owned_outpoints)?;
 
             for spent in spent {
                 let hex: &[u8] = spent.as_ref();
-
                 if let Some(outpoint) = input_hashes_map.get(hex) {
                     res.insert(*outpoint);
                 }
@@ -293,60 +261,6 @@ impl<'a> SpScanner<'a> {
         }
 
         Ok(res)
-    }
-
-    // Check if this block contains relevant transactions
-    fn check_block_outputs(
-        created_utxo_filter: BlockFilter,
-        blkhash: BlockHash,
-        candidate_spks: Vec<&[u8; 34]>,
-    ) -> Result<bool> {
-        // check output scripts
-        let output_keys: Vec<_> = candidate_spks
-            .into_iter()
-            .map(|spk| spk[2..].as_ref())
-            .collect();
-
-        // note: match will always return true for an empty query!
-        if !output_keys.is_empty() {
-            Ok(created_utxo_filter.match_any(&blkhash, &mut output_keys.into_iter())?)
-        } else {
-            Ok(false)
-        }
-    }
-
-    fn get_input_hashes(&self, blkhash: BlockHash) -> Result<HashMap<[u8; 8], OutPoint>> {
-        let mut map: HashMap<[u8; 8], OutPoint> = HashMap::new();
-
-        for outpoint in &self.owned_outpoints {
-            let mut arr = [0u8; 68];
-            arr[..32].copy_from_slice(&outpoint.txid.to_raw_hash().to_byte_array());
-            arr[32..36].copy_from_slice(&outpoint.vout.to_le_bytes());
-            arr[36..].copy_from_slice(&blkhash.to_byte_array());
-            let hash = sha256::Hash::hash(&arr);
-
-            let mut res = [0u8; 8];
-            res.copy_from_slice(&hash[..8]);
-
-            map.insert(res, *outpoint);
-        }
-
-        Ok(map)
-    }
-
-    // Check if this block contains relevant transactions
-    fn check_block_inputs(
-        &self,
-        spent_filter: BlockFilter,
-        blkhash: BlockHash,
-        input_hashes: Vec<[u8; 8]>,
-    ) -> Result<bool> {
-        // note: match will always return true for an empty query!
-        if !input_hashes.is_empty() {
-            Ok(spent_filter.match_any(&blkhash, &mut input_hashes.into_iter())?)
-        } else {
-            Ok(false)
-        }
     }
 
     fn interrupt_requested(&self) -> bool {

--- a/spdk-wallet/src/scanner/scanner.rs
+++ b/spdk-wallet/src/scanner/scanner.rs
@@ -166,28 +166,23 @@ impl<'a> SpScanner<'a> {
         Ok(res)
     }
 
-    async fn process_block_inputs(
-        &self,
-        blockdata: &(dyn BlockData + Send + Sync),
-    ) -> Result<HashSet<OutPoint>> {
-        let mut res = HashSet::new();
-
+    async fn process_block_inputs(&self, blockdata: &BoxedBlockData) -> Result<HashSet<OutPoint>> {
         let match_on_inputs = blockdata.check_match_inputs(&self.owned_outpoints)?;
 
-        // if match: download spent data, collect the outpoints that are spent
         if match_on_inputs {
+            // if match: return the set of all outpoints that have been spent this block
             info!("matched inputs on: {}", blockdata.blkheight());
-            let spent = self.backend.spent_index(blockdata.blkheight()).await?.data;
-            let input_hashes_map = blockdata.input_hashes_map(&self.owned_outpoints)?;
-
-            for spent in spent {
-                let hex: &[u8] = spent.as_ref();
-                if let Some(outpoint) = input_hashes_map.get(hex) {
-                    res.insert(*outpoint);
-                }
-            }
+            self.backend
+                .detect_spent_outpoints(
+                    blockdata.blkheight(),
+                    blockdata.blkhash(),
+                    self.owned_outpoints.clone(),
+                )
+                .await
+        } else {
+            // no match: return an empty set
+            Ok(HashSet::new())
         }
-        Ok(res)
     }
 
     async fn scan_utxos(

--- a/spdk-wallet/tests/mock/chain.rs
+++ b/spdk-wallet/tests/mock/chain.rs
@@ -2,11 +2,17 @@ use anyhow::Result;
 use backend_blindbit_v1::{
     api_structs::{FilterResponse, SpentIndexResponse, UtxoResponse},
     structs::BlindbitV1BlockData,
+    utils::input_hashes_map,
 };
-use std::{fs::File, ops::RangeInclusive, pin::Pin};
+use std::collections::HashSet;
+use std::fs::File;
+use std::ops::RangeInclusive;
+use std::pin::Pin;
 
 use async_trait::async_trait;
-use bitcoin::{Amount, absolute::Height, secp256k1::PublicKey};
+use bitcoin::absolute::Height;
+use bitcoin::secp256k1::PublicKey;
+use bitcoin::{Amount, BlockHash, OutPoint};
 use futures::{Stream, stream};
 
 use spdk_core::chain::{BoxedBlockData, ChainBackend, SpentIndexData, UtxoData};
@@ -52,12 +58,30 @@ impl ChainBackend for MockChainBackend {
         Box::pin(stream)
     }
 
-    async fn spent_index(&self, block_height: Height) -> Result<SpentIndexData> {
+    async fn detect_spent_outpoints(
+        &self,
+        block_height: Height,
+        block_hash: BlockHash,
+        outpoints: HashSet<OutPoint>,
+    ) -> Result<HashSet<OutPoint>> {
         let file =
             File::open(format!("{BLOCK_DATA_PATH}/{block_height}/spent-index.json")).unwrap();
         let spent_index: SpentIndexResponse = serde_json::from_reader(file).unwrap();
 
-        Ok(spent_index.into())
+        let index_data: SpentIndexData = spent_index.into();
+
+        let hashes_to_outpoint = input_hashes_map(&outpoints, block_hash)?;
+
+        let mut res = HashSet::new();
+
+        for spent in index_data.data {
+            let hex: &[u8] = spent.as_ref();
+            if let Some(outpoint) = hashes_to_outpoint.get(hex) {
+                res.insert(*outpoint);
+            }
+        }
+
+        Ok(res)
     }
 
     async fn utxos(&self, block_height: Height) -> Result<Vec<UtxoData>> {

--- a/spdk-wallet/tests/mock/chain.rs
+++ b/spdk-wallet/tests/mock/chain.rs
@@ -1,12 +1,15 @@
 use anyhow::Result;
-use backend_blindbit_v1::api_structs::{FilterResponse, SpentIndexResponse, UtxoResponse};
+use backend_blindbit_v1::{
+    api_structs::{FilterResponse, SpentIndexResponse, UtxoResponse},
+    structs::BlindbitV1BlockData,
+};
 use std::{fs::File, ops::RangeInclusive, pin::Pin};
 
 use async_trait::async_trait;
 use bitcoin::{Amount, absolute::Height, secp256k1::PublicKey};
 use futures::{Stream, stream};
 
-use spdk_core::chain::{BlockData, ChainBackend, SpentIndexData, UtxoData};
+use spdk_core::chain::{BoxedBlockData, ChainBackend, SpentIndexData, UtxoData};
 
 const BLOCK_DATA_PATH: &str = "tests/resources/blocks";
 
@@ -19,7 +22,7 @@ impl ChainBackend for MockChainBackend {
         range: RangeInclusive<Height>,
         _dust_limit: Amount,
         _with_cutthrough: bool,
-    ) -> Pin<Box<dyn Stream<Item = Result<BlockData>> + Send>> {
+    ) -> Pin<Box<dyn Stream<Item = Result<BoxedBlockData>> + Send>> {
         let range = range.start().to_consensus_u32()..=range.end().to_consensus_u32();
 
         let values = range.map(move |n| {
@@ -35,13 +38,13 @@ impl ChainBackend for MockChainBackend {
             let blkhash = new_utxo_filter.block_hash;
             let blkheight = new_utxo_filter.block_height;
 
-            Ok(BlockData {
+            Ok(Box::new(BlindbitV1BlockData {
                 blkheight,
                 blkhash,
                 tweaks,
                 new_utxo_filter: new_utxo_filter.into(),
                 spent_filter: spent_filter.into(),
-            })
+            }) as BoxedBlockData)
         });
 
         let stream = stream::iter(values);


### PR DESCRIPTION
- Instead of doing bip158 filter checking on the scanner side, use a BlockData trait that exposes `check_match_inputs` and `check_match_outputs`, which implements either bip158 filters or any other type, depending on the backend type
- Replace `ChainBackend::spent_index` with `detect_spent_outpoints`. Instead of having the scanner parse the spent index, move the responsibility to the chain backend.